### PR TITLE
:sparkles: Implemented score export for the running game and high score per level.

### DIFF
--- a/Assets/Levels/Level 1 - Tutorial/Level 1 - Scene - Interactable.unity
+++ b/Assets/Levels/Level 1 - Tutorial/Level 1 - Scene - Interactable.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311926, g: 0.38073996, b: 0.35872683, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,68 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &902026398
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1614249374}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.08
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -6.236
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 13.357
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-      propertyPath: m_Name
-      value: roof_T
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
---- !u!4 &902026399 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
-  m_PrefabInstance: {fileID: 902026398}
-  m_PrefabAsset: {fileID: 0}
 --- !u!850595691 &940766566
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -249,68 +187,6 @@ LightingSettings:
   m_PVRTiledBaking: 0
   m_NumRaysToShootPerTexel: -1
   m_RespectSceneVisibilityWhenBakingGI: 0
---- !u!1001 &1260193686
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1614249374}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.0802474
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -6.2284346
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 13.45693
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-      propertyPath: m_Name
-      value: hose_base_A
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 91d294ea19725d74da98dae21162af61, type: 3}
---- !u!4 &1260193687 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
-  m_PrefabInstance: {fileID: 1260193686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!43 &1261490683
 Mesh:
   m_ObjectHideFlags: 0
@@ -476,39 +352,63 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1614249373
-GameObject:
+--- !u!1001 &1577412653
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1614249374}
-  m_Layer: 0
-  m_Name: Level  Goal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1614249374
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1614249373}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: -14.911, y: 8.231412, z: 23.123999}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1260193687}
-  - {fileID: 902026399}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 390586958444697017, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8716964725565385577, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
+      propertyPath: m_Name
+      value: House (Goal) Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9e6c544d8c0dc53d0bba802b0788e297, type: 3}
 --- !u!1001 &1637385399
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -627,5 +527,5 @@ Transform:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1614249374}
+  - {fileID: 1577412653}
   - {fileID: 1798943567}

--- a/Assets/Levels/Level 1 - Tutorial/ScriptableObjects/Level 1.asset
+++ b/Assets/Levels/Level 1 - Tutorial/ScriptableObjects/Level 1.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Level 1
   m_EditorClassIdentifier: 
   uniqueID: 8af65abf-8f3e-4b27-95ee-38730ce873db
-  LastUpdated: 06.12.23 11:46:37
+  LastUpdated: 08/12/23 23:00:33
   LastUpdatedBy: 
   Notes: 
   Description: 
@@ -23,3 +23,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e50d498980839a945b2174a3d0cfa9f7, type: 2}
   - {fileID: 11400000, guid: d118fb68867224e46a4cb7f6cfa555e4, type: 2}
   - {fileID: 11400000, guid: 65524cc07ae37b342a50eb3489de2656, type: 2}
+  highestScore: -1
+  highestStars: -1
+  leastDamage: -1
+  fastedPlayDuration: 0

--- a/Assets/Levels/Level 2 - First Delivery/ScriptableObjects/Level 2.asset
+++ b/Assets/Levels/Level 2 - First Delivery/ScriptableObjects/Level 2.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Level 2
   m_EditorClassIdentifier: 
   uniqueID: 8af65abf-8f3e-4b27-95ee-38730ce873db
-  LastUpdated: 05.12.23 11:02:07
+  LastUpdated: 08/12/23 23:00:33
   LastUpdatedBy: 
   Notes: 
   Description: 
@@ -23,3 +23,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 38940d433888aea47878255f68eedbbb, type: 2}
   - {fileID: 11400000, guid: a65399a23c23b11489b28650a0eaa9fd, type: 2}
   - {fileID: 11400000, guid: c208da94d2bbbcf4297eda1a7fe0f0c2, type: 2}
+  highestScore: -1
+  highestStars: -1
+  leastDamage: -1
+  fastedPlayDuration: 0

--- a/Assets/Levels/Level 3 - Reaching Heights/ScriptableObjects/Level 3.asset
+++ b/Assets/Levels/Level 3 - Reaching Heights/ScriptableObjects/Level 3.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Level 3
   m_EditorClassIdentifier: 
   uniqueID: 8af65abf-8f3e-4b27-95ee-38730ce873db
-  LastUpdated: 05.12.23 11:03:13
+  LastUpdated: 08/12/23 23:00:33
   LastUpdatedBy: 
   Notes: 
   Description: 
@@ -23,3 +23,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 3b247e0c2cbd9674fb54839dc3c33927, type: 2}
   - {fileID: 11400000, guid: 1e1d5ce2d52252543a62d18d3d27a0c7, type: 2}
   - {fileID: 11400000, guid: a90b923402bbdb640a26f55d223c71ef, type: 2}
+  highestScore: -1
+  highestStars: -1
+  leastDamage: -1
+  fastedPlayDuration: 0

--- a/Assets/Levels/Level 4 - You, again.._/ScriptableObjects/Level 4.asset
+++ b/Assets/Levels/Level 4 - You, again.._/ScriptableObjects/Level 4.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Level 4
   m_EditorClassIdentifier: 
   uniqueID: 8af65abf-8f3e-4b27-95ee-38730ce873db
-  LastUpdated: 05.12.23 11:03:25
+  LastUpdated: 08/12/23 23:00:32
   LastUpdatedBy: 
   Notes: 
   Description: 
@@ -23,3 +23,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: dbb5922b9d410f947b02e804e9411497, type: 2}
   - {fileID: 11400000, guid: 51874d21db96b214dbec462ce336b797, type: 2}
   - {fileID: 11400000, guid: 2f063b8500e264642ba940a4b1b79552, type: 2}
+  highestScore: -1
+  highestStars: -1
+  leastDamage: -1
+  fastedPlayDuration: 0

--- a/Assets/Prefabs/House (Goal) Variant.prefab
+++ b/Assets/Prefabs/House (Goal) Variant.prefab
@@ -1,0 +1,196 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1813704005643551632
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 390586958444697017}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.3859692
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.366
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.291
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+      propertyPath: m_Name
+      value: roof_T
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+--- !u!4 &2207092925566493819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: dfd12ff500cbbc7439e06321c0f5feda, type: 3}
+  m_PrefabInstance: {fileID: 1813704005643551632}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4092110218866203408
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4626034284051525753, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      propertyPath: m_Name
+      value: House (Goal) Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 1065683076101524330, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+    - {fileID: 3541305174708986523, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4375905139018260173}
+    - targetCorrespondingSourceObject: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2207092925566493819}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+--- !u!4 &390586958444697017 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4441037779861442217, guid: 27e096c0c418a8c408acb4ab47b33017, type: 3}
+  m_PrefabInstance: {fileID: 4092110218866203408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4265172693055191334
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 390586958444697017}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.463444
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.365905
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.191884
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+      propertyPath: m_Name
+      value: hose_base_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+--- !u!4 &4375905139018260173 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 91d294ea19725d74da98dae21162af61, type: 3}
+  m_PrefabInstance: {fileID: 4265172693055191334}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/House (Goal) Variant.prefab.meta
+++ b/Assets/Prefabs/House (Goal) Variant.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: 637a802b113c8c1d395a4bbc310257bd
-NativeFormatImporter:
+guid: 9e6c544d8c0dc53d0bba802b0788e297
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Prefabs/House (Goal).prefab
+++ b/Assets/Prefabs/House (Goal).prefab
@@ -9,6 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4441037779861442217}
+  - component: {fileID: 6328641113057784196}
+  - component: {fileID: 6480162865529540717}
   m_Layer: 0
   m_Name: House (Goal)
   m_TagString: Untagged
@@ -33,6 +35,43 @@ Transform:
   - {fileID: 396811204122448336}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6328641113057784196
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4626034284051525753}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.553028, y: 5.0828967, z: 3.3941228}
+  m_Center: {x: -1.4061031, y: -0.33439088, z: -0.93203676}
+--- !u!114 &6480162865529540717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4626034284051525753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d6462b4750be394faea10f7e2ed352b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onLevelFinished: {fileID: 11400000, guid: 85be3facf32ba011c867e2db1e5b44b9, type: 2}
+  OnLevelEnd:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &147344236530923067
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Main Camera.prefab
+++ b/Assets/Prefabs/Main Camera.prefab
@@ -10,8 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 6894288160074923862}
   - component: {fileID: 2936902058282395217}
-  - component: {fileID: 8270598076678649711}
   - component: {fileID: 2767919810607208247}
+  - component: {fileID: 8659238141797362881}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -140,10 +140,10 @@ MonoBehaviour:
     m_Radius: 19
   m_LegacyHeadingBias: 3.4028235e+38
   m_Rigs:
-  - {fileID: 7303048109446886997}
-  - {fileID: 5136644323402927872}
-  - {fileID: 4222941585642178676}
---- !u!114 &8270598076678649711
+  - {fileID: 5541705502334473562}
+  - {fileID: 4467101777734058481}
+  - {fileID: 835648809873629509}
+--- !u!114 &2767919810607208247
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -152,11 +152,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 271638698089058363}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19898f411b47add9586d9ee6a1a55f31, type: 3}
+  m_Script: {fileID: 11500000, guid: 55f0f3d568c547feaa78f3cffc0547d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerKey: {fileID: 11400000, guid: 4b50b2cea39dfac12bd6942eb6f3dbe1, type: 2}
+--- !u!114 &8659238141797362881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 271638698089058363}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 011f4f49762548898a9c1b71496a8b35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   description: 
-  Event: {fileID: 11400000, guid: 637a802b113c8c1d395a4bbc310257bd, type: 2}
+  Event: {fileID: 11400000, guid: c706edf7c8f78c26db7eb1dfabe9b476, type: 2}
   Response:
     m_PersistentCalls:
       m_Calls:
@@ -172,19 +185,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &2767919810607208247
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 271638698089058363}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 55f0f3d568c547feaa78f3cffc0547d8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &4845685649294145380
+--- !u!1 &3146266340839533488
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -192,10 +193,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 220461273357773750}
-  - component: {fileID: 1447290764126229305}
-  - component: {fileID: 5793221176036557718}
-  - component: {fileID: 341117489879340153}
+  - component: {fileID: 3663737554341815648}
+  - component: {fileID: 1244636342524424219}
+  - component: {fileID: 5562443879795937183}
+  - component: {fileID: 7855183096996784059}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -203,13 +204,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &220461273357773750
+--- !u!4 &3663737554341815648
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4845685649294145380}
+  m_GameObject: {fileID: 3146266340839533488}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.0000000037252894, w: 1}
   m_LocalPosition: {x: -0.000010011327, y: -0, z: -0}
@@ -218,25 +219,25 @@ Transform:
   m_Children: []
   m_Father: {fileID: 755076439180318389}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1447290764126229305
+--- !u!114 &1244636342524424219
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4845685649294145380}
+  m_GameObject: {fileID: 3146266340839533488}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5793221176036557718
+--- !u!114 &5562443879795937183
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4845685649294145380}
+  m_GameObject: {fileID: 3146266340839533488}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
@@ -284,13 +285,13 @@ MonoBehaviour:
   m_LegacyHeightOffset: 3.4028235e+38
   m_LegacyHeadingBias: 3.4028235e+38
   m_HeadingIsSlave: 1
---- !u!114 &341117489879340153
+--- !u!114 &7855183096996784059
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4845685649294145380}
+  m_GameObject: {fileID: 3146266340839533488}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
@@ -311,7 +312,7 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
---- !u!1 &5958637472844127877
+--- !u!1 &6455359507078555507
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -319,10 +320,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1532495362779661454}
-  - component: {fileID: 7938350327551804518}
-  - component: {fileID: 6990261487837647699}
-  - component: {fileID: 4487127129783598595}
+  - component: {fileID: 4882349410202124843}
+  - component: {fileID: 5857628682800836389}
+  - component: {fileID: 5711135038665964054}
+  - component: {fileID: 676201108489493981}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -330,13 +331,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1532495362779661454
+--- !u!4 &4882349410202124843
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5958637472844127877}
+  m_GameObject: {fileID: 6455359507078555507}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.0000000037252894, w: 1}
   m_LocalPosition: {x: -0.000010011327, y: -0, z: -0}
@@ -345,25 +346,25 @@ Transform:
   m_Children: []
   m_Father: {fileID: 5757360464001310636}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7938350327551804518
+--- !u!114 &5857628682800836389
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5958637472844127877}
+  m_GameObject: {fileID: 6455359507078555507}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &6990261487837647699
+--- !u!114 &5711135038665964054
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5958637472844127877}
+  m_GameObject: {fileID: 6455359507078555507}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
@@ -411,13 +412,13 @@ MonoBehaviour:
   m_LegacyHeightOffset: 3.4028235e+38
   m_LegacyHeadingBias: 3.4028235e+38
   m_HeadingIsSlave: 1
---- !u!114 &4487127129783598595
+--- !u!114 &676201108489493981
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5958637472844127877}
+  m_GameObject: {fileID: 6455359507078555507}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
@@ -447,7 +448,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5757360464001310636}
-  - component: {fileID: 5136644323402927872}
+  - component: {fileID: 4467101777734058481}
   m_Layer: 0
   m_Name: MiddleRig
   m_TagString: Untagged
@@ -468,10 +469,10 @@ Transform:
   m_LocalScale: {x: 0.99999964, y: 1, z: 0.99999976}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1532495362779661454}
+  - {fileID: 4882349410202124843}
   m_Father: {fileID: 6894288160074923862}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5136644323402927872
+--- !u!114 &4467101777734058481
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
@@ -516,7 +517,134 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 1532495362779661454}
+  m_ComponentOwner: {fileID: 4882349410202124843}
+--- !u!1 &6831257466511322441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3017687131211846341}
+  - component: {fileID: 3015968752707776974}
+  - component: {fileID: 4633725949825224581}
+  - component: {fileID: 1589404745320414591}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3017687131211846341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6831257466511322441}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000037252894, w: 1}
+  m_LocalPosition: {x: -0.000010011327, y: -0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2649572161863856201}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3015968752707776974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6831257466511322441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4633725949825224581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6831257466511322441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 5
+  m_FollowOffset: {x: 0, y: 6, z: -20}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+  m_Heading:
+    m_Definition: 2
+    m_VelocityFilterStrength: 4
+    m_Bias: 0
+  m_RecenterToTargetHeading:
+    m_enabled: 0
+    m_WaitTime: 1
+    m_RecenteringTime: 2
+    m_LegacyHeadingDefinition: -1
+    m_LegacyVelocityFilterStrength: -1
+  m_XAxis:
+    Value: 0
+    m_SpeedMode: 0
+    m_MaxSpeed: 300
+    m_AccelTime: 0.1
+    m_DecelTime: 0.1
+    m_InputAxisName: 
+    m_InputAxisValue: 0
+    m_InvertInput: 1
+    m_MinValue: -180
+    m_MaxValue: 180
+    m_Wrap: 1
+    m_Recentering:
+      m_enabled: 0
+      m_WaitTime: 1
+      m_RecenteringTime: 2
+      m_LegacyHeadingDefinition: -1
+      m_LegacyVelocityFilterStrength: -1
+  m_LegacyRadius: 3.4028235e+38
+  m_LegacyHeightOffset: 3.4028235e+38
+  m_LegacyHeadingBias: 3.4028235e+38
+  m_HeadingIsSlave: 1
+--- !u!114 &1589404745320414591
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6831257466511322441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0
+  m_VerticalDamping: 0
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
 --- !u!1 &7401780609898059030
 GameObject:
   m_ObjectHideFlags: 3
@@ -526,7 +654,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2649572161863856201}
-  - component: {fileID: 4222941585642178676}
+  - component: {fileID: 835648809873629509}
   m_Layer: 0
   m_Name: BottomRig
   m_TagString: Untagged
@@ -547,10 +675,10 @@ Transform:
   m_LocalScale: {x: 0.99999964, y: 1, z: 0.99999976}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7562703269459379471}
+  - {fileID: 3017687131211846341}
   m_Father: {fileID: 6894288160074923862}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4222941585642178676
+--- !u!114 &835648809873629509
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
@@ -595,7 +723,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 7562703269459379471}
+  m_ComponentOwner: {fileID: 3017687131211846341}
 --- !u!1 &7465637030850627706
 GameObject:
   m_ObjectHideFlags: 3
@@ -605,7 +733,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 755076439180318389}
-  - component: {fileID: 7303048109446886997}
+  - component: {fileID: 5541705502334473562}
   m_Layer: 0
   m_Name: TopRig
   m_TagString: Untagged
@@ -626,10 +754,10 @@ Transform:
   m_LocalScale: {x: 0.99999964, y: 1, z: 0.99999976}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 220461273357773750}
+  - {fileID: 3663737554341815648}
   m_Father: {fileID: 6894288160074923862}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7303048109446886997
+--- !u!114 &5541705502334473562
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_CorrespondingSourceObject: {fileID: 0}
@@ -674,7 +802,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls: []
   m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 220461273357773750}
+  m_ComponentOwner: {fileID: 3663737554341815648}
 --- !u!1 &7562787479005770310
 GameObject:
   m_ObjectHideFlags: 0
@@ -807,130 +935,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   key: {fileID: 11400000, guid: 25c528c808ab450f9a5a01d95a6f1b54, type: 2}
---- !u!1 &7705485731454827978
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7562703269459379471}
-  - component: {fileID: 7792023637134474901}
-  - component: {fileID: 328923254384548821}
-  - component: {fileID: 9046953720984262923}
-  m_Layer: 0
-  m_Name: cm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7562703269459379471
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7705485731454827978}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000037252894, w: 1}
-  m_LocalPosition: {x: -0.000010011327, y: -0, z: -0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2649572161863856201}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7792023637134474901
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7705485731454827978}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &328923254384548821
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7705485731454827978}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_BindingMode: 5
-  m_FollowOffset: {x: 0, y: 6, z: -20}
-  m_XDamping: 1
-  m_YDamping: 1
-  m_ZDamping: 1
-  m_AngularDampingMode: 0
-  m_PitchDamping: 0
-  m_YawDamping: 0
-  m_RollDamping: 0
-  m_AngularDamping: 0
-  m_Heading:
-    m_Definition: 2
-    m_VelocityFilterStrength: 4
-    m_Bias: 0
-  m_RecenterToTargetHeading:
-    m_enabled: 0
-    m_WaitTime: 1
-    m_RecenteringTime: 2
-    m_LegacyHeadingDefinition: -1
-    m_LegacyVelocityFilterStrength: -1
-  m_XAxis:
-    Value: 0
-    m_SpeedMode: 0
-    m_MaxSpeed: 300
-    m_AccelTime: 0.1
-    m_DecelTime: 0.1
-    m_InputAxisName: 
-    m_InputAxisValue: 0
-    m_InvertInput: 1
-    m_MinValue: -180
-    m_MaxValue: 180
-    m_Wrap: 1
-    m_Recentering:
-      m_enabled: 0
-      m_WaitTime: 1
-      m_RecenteringTime: 2
-      m_LegacyHeadingDefinition: -1
-      m_LegacyVelocityFilterStrength: -1
-  m_LegacyRadius: 3.4028235e+38
-  m_LegacyHeightOffset: 3.4028235e+38
-  m_LegacyHeadingBias: 3.4028235e+38
-  m_HeadingIsSlave: 1
---- !u!114 &9046953720984262923
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7705485731454827978}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
-  m_LookaheadTime: 0
-  m_LookaheadSmoothing: 0
-  m_LookaheadIgnoreY: 0
-  m_HorizontalDamping: 0
-  m_VerticalDamping: 0
-  m_ScreenX: 0.5
-  m_ScreenY: 0.6
-  m_DeadZoneWidth: 0
-  m_DeadZoneHeight: 0
-  m_SoftZoneWidth: 0.8
-  m_SoftZoneHeight: 0.8
-  m_BiasX: 0
-  m_BiasY: 0
-  m_CenterOnActivate: 1

--- a/Assets/Prefabs/ScoringSystem.prefab
+++ b/Assets/Prefabs/ScoringSystem.prefab
@@ -11,7 +11,8 @@ GameObject:
   - component: {fileID: 427101594339613949}
   - component: {fileID: 4250889762398308135}
   - component: {fileID: 6016074107099939056}
-  - component: {fileID: 5758215060113739106}
+  - component: {fileID: 7689759737550137927}
+  - component: {fileID: 4391477675360393640}
   m_Layer: 0
   m_Name: ScoringSystem
   m_TagString: Untagged
@@ -82,50 +83,14 @@ MonoBehaviour:
   oneStarScore: 10
   onScoreChanged:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 5758215060113739106}
-        m_TargetAssemblyTypeName: TestEvents, Assembly-CSharp
-        m_MethodName: HandleScoreChanged
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   onStarsChanged:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 5758215060113739106}
-        m_TargetAssemblyTypeName: TestEvents, Assembly-CSharp
-        m_MethodName: HandleStarsChanged
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   onZeroScore:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 5758215060113739106}
-        m_TargetAssemblyTypeName: TestEvents, Assembly-CSharp
-        m_MethodName: HandleZeroStars
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &5758215060113739106
+      m_Calls: []
+--- !u!114 &7689759737550137927
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -134,6 +99,52 @@ MonoBehaviour:
   m_GameObject: {fileID: 1925995388798499296}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c1c4cfc56c2111c0990ce165dcb6c413, type: 3}
+  m_Script: {fileID: 11500000, guid: 011f4f49762548898a9c1b71496a8b35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  description: 
+  Event: {fileID: 11400000, guid: c706edf7c8f78c26db7eb1dfabe9b476, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6016074107099939056}
+        m_TargetAssemblyTypeName: ScoringSystem.Scoring, Assembly-CSharp
+        m_MethodName: OnLevelLoaded
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4391477675360393640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925995388798499296}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19898f411b47add9586d9ee6a1a55f31, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  description: 
+  Event: {fileID: 11400000, guid: 85be3facf32ba011c867e2db1e5b44b9, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6016074107099939056}
+        m_TargetAssemblyTypeName: ScoringSystem.Scoring, Assembly-CSharp
+        m_MethodName: OnLevelFinished
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Prefabs/Wheelchair.prefab
+++ b/Assets/Prefabs/Wheelchair.prefab
@@ -155,9 +155,9 @@ GameObject:
   - component: {fileID: 300702046746616682}
   - component: {fileID: 5289835253562997767}
   - component: {fileID: 2239084278870708584}
-  - component: {fileID: 7634850687694973646}
   - component: {fileID: 1029262612729288116}
   - component: {fileID: 4286392136521160861}
+  - component: {fileID: 1034009233178127198}
   m_Layer: 0
   m_Name: Canvas
   m_TagString: Untagged
@@ -277,35 +277,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &7634850687694973646
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3408567177451498049}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19898f411b47add9586d9ee6a1a55f31, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  description: 
-  Event: {fileID: 11400000, guid: 637a802b113c8c1d395a4bbc310257bd, type: 2}
-  Response:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1029262612729288116}
-        m_TargetAssemblyTypeName: InteractionPrompt_Script, Assembly-CSharp
-        m_MethodName: OnLevelLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!114 &1029262612729288116
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,6 +304,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   key: {fileID: 11400000, guid: dbe51d2f6e8fdaa8281617e51ce5610f, type: 2}
+--- !u!114 &1034009233178127198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3408567177451498049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 011f4f49762548898a9c1b71496a8b35, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  description: 
+  Event: {fileID: 11400000, guid: c706edf7c8f78c26db7eb1dfabe9b476, type: 2}
+  Response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1029262612729288116}
+        m_TargetAssemblyTypeName: InteractionPrompt_Script, Assembly-CSharp
+        m_MethodName: OnLevelLoaded
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3702447685517162991
 GameObject:
   m_ObjectHideFlags: 0
@@ -655,8 +655,8 @@ GameObject:
   - component: {fileID: 7141186920343473040}
   - component: {fileID: 5140380552920738614}
   - component: {fileID: 2204376500829678680}
-  - component: {fileID: 8608793170659052431}
   - component: {fileID: 5707039260468472699}
+  - component: {fileID: 6090906129175626}
   m_Layer: 0
   m_Name: CapsulePlayer
   m_TagString: Player
@@ -882,7 +882,7 @@ MonoBehaviour:
   bakeKeys: []
   bakeValues: []
   OutlineDistanceMultipy: 0.1
---- !u!114 &8608793170659052431
+--- !u!114 &5707039260468472699
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -891,11 +891,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 7230004498888904527}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19898f411b47add9586d9ee6a1a55f31, type: 3}
+  m_Script: {fileID: 11500000, guid: f05e60d6444d490681d93c75036fc57d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  key: {fileID: 11400000, guid: 4b50b2cea39dfac12bd6942eb6f3dbe1, type: 2}
+--- !u!114 &6090906129175626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7230004498888904527}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 011f4f49762548898a9c1b71496a8b35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   description: 
-  Event: {fileID: 11400000, guid: 637a802b113c8c1d395a4bbc310257bd, type: 2}
+  Event: {fileID: 11400000, guid: c706edf7c8f78c26db7eb1dfabe9b476, type: 2}
   Response:
     m_PersistentCalls:
       m_Calls:
@@ -911,19 +924,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &5707039260468472699
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7230004498888904527}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f05e60d6444d490681d93c75036fc57d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  key: {fileID: 11400000, guid: 4b50b2cea39dfac12bd6942eb6f3dbe1, type: 2}
 --- !u!1 &8164078558771037576
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BootLoader.unity
+++ b/Assets/Scenes/BootLoader.unity
@@ -158,7 +158,8 @@ MonoBehaviour:
   - {fileID: 271638698089058363, guid: f47cde4cfa9eb4c45b87851bda4d1791, type: 3}
   - {fileID: 2071269133518141234, guid: 6964ecb59d5cdc94f95b5daf52166b69, type: 3}
   - {fileID: 5548672860729758588, guid: b5e260a65851c664989061965f804b95, type: 3}
-  onLevelLoaded: {fileID: 11400000, guid: 637a802b113c8c1d395a4bbc310257bd, type: 2}
+  - {fileID: 1925995388798499296, guid: e1d02349032435d5a98ccd2eb1697137, type: 3}
+  onLevelLoaded: {fileID: 11400000, guid: c706edf7c8f78c26db7eb1dfabe9b476, type: 2}
 --- !u!4 &1548237271
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/LevelFinishedEvent.asset
+++ b/Assets/ScriptableObjects/LevelFinishedEvent.asset
@@ -10,5 +10,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fc1097c1c33e5e6d6878f51eb92c4fa8, type: 3}
-  m_Name: LevelLoaded
+  m_Name: LevelFinishedEvent
   m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/LevelFinishedEvent.asset.meta
+++ b/Assets/ScriptableObjects/LevelFinishedEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85be3facf32ba011c867e2db1e5b44b9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/LevelLoadedEvent.asset
+++ b/Assets/ScriptableObjects/LevelLoadedEvent.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e953b3003304bd38da59c9dbb1d76f9, type: 3}
+  m_Name: LevelLoadedEvent
+  m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/LevelLoadedEvent.asset.meta
+++ b/Assets/ScriptableObjects/LevelLoadedEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c706edf7c8f78c26db7eb1dfabe9b476
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AssignPlayerToCinemachine.cs
+++ b/Assets/Scripts/AssignPlayerToCinemachine.cs
@@ -4,11 +4,13 @@ using UnityEngine;
 
 public class AssignPlayerToCinemachine : MonoBehaviour
 {
-    public void FindAndAttachPlayer(Empty empty)
+    [SerializeField]
+    private SearchableObjectKey playerKey;
+    
+    public void FindAndAttachPlayer(GameLevel level)
     {
         CinemachineFreeLook freeLook = transform.GetComponent<CinemachineFreeLook>();
-        //TODO: implement in a more flexible manner
-        Transform playerTransform = GameObject.Find("CapsulePlayer").transform;
+        Transform playerTransform = SearchableObjects.FindObject(playerKey).transform;
         freeLook.LookAt = playerTransform;
         freeLook.Follow = playerTransform;
     }

--- a/Assets/Scripts/Birds.cs
+++ b/Assets/Scripts/Birds.cs
@@ -29,7 +29,7 @@ public class Birds : MonoBehaviour
         }
     }
     
-    public void OnLevelLoaded(Empty empty)
+    public void OnLevelLoaded(GameLevel level)
     {
         FindNewTree(null);
     }

--- a/Assets/Scripts/LevelFinishReached.cs
+++ b/Assets/Scripts/LevelFinishReached.cs
@@ -1,6 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics.Tracing;
+using GD;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
@@ -8,12 +6,19 @@ using UnityEngine.SceneManagement;
 public class LevelFinishReached : MonoBehaviour
 {
 
+    [SerializeField]
+    private EmptyGameEvent onLevelFinished;
+    
+    //Todo: can all be done with above Event
     public UnityEvent OnLevelEnd;
 
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("Player"))
         {
+            onLevelFinished.Raise(new Empty());
+            //TODO: Remove code below it doesn't work with the split scenes. Level Switching shouldn't be implemented here, but just somewhere with a listener to the above event
+            
             //Tell Level Manager to go to next level
 
             OnLevelEnd?.Invoke();

--- a/Assets/Scripts/LevelLoading/Bootloader.cs
+++ b/Assets/Scripts/LevelLoading/Bootloader.cs
@@ -21,7 +21,7 @@ namespace GD
 
         [SerializeField]
         [Tooltip("This event gets called when all components of the level are loaded.")]
-        private EmptyGameEvent onLevelLoaded;
+        private LevelGameEvent onLevelLoaded;
         
         private bool isLoaded = false;
         
@@ -48,9 +48,7 @@ namespace GD
         private void LevelLoaded()
         {
             isLoaded = true;
-            
-            if(onLevelLoaded)
-                onLevelLoaded.Raise(new Empty());
+            onLevelLoaded.Raise(gameLayout.Levels[gameLayout.CurrentLevel]);
         }
 
         private void LoadGameLayout()

--- a/Assets/Scripts/LevelLoading/GameLevel.cs
+++ b/Assets/Scripts/LevelLoading/GameLevel.cs
@@ -1,7 +1,7 @@
-﻿using Sirenix.OdinInspector;
+﻿using System;
+using Sirenix.OdinInspector;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 /// <summary>
 /// Stores data relating to a level comprised of multiple scenes
@@ -16,6 +16,28 @@ namespace GD
         [Searchable]
         public List<GameScene> Scenes;
 
+        public int highestScore = -1;
+        public int highestStars = -1;
+        public int leastDamage = -1;
+        
+        [HorizontalGroup("fastestPlayDuration")]
+        public double fastedPlayDuration = 0; //in seconds
+        [ShowInInspector] [ReadOnly] [LabelText("")]
+        [HorizontalGroup("fastestPlayDuration", Width = 50)]
+        public string FastedPlayDurationString => TimeSpan.FromSeconds(fastedPlayDuration).ToString(@"mm\:ss");
+
+
+        [Button]
+        public void ResetHighScore()
+        {
+            highestScore = -1;
+            highestStars = -1;
+            leastDamage = -1;
+            
+            fastedPlayDuration = 0;
+        }
+        
+        
         public void LoadLevel(AsyncOperationsWatcher watcher)
         {
             foreach (GameScene scene in Scenes)

--- a/Assets/Scripts/UI/InteractionPrompt_Script.cs
+++ b/Assets/Scripts/UI/InteractionPrompt_Script.cs
@@ -13,7 +13,7 @@ public class InteractionPrompt_Script : MonoBehaviour
 
     private GameObject _mainCam;
 
-    public void OnLevelLoaded(Empty empty)
+    public void OnLevelLoaded(GameLevel level)
     {
         _mainCam = SearchableObjects.FindObject(mainCameraKey);
         Debug.Log($"Camera: {_mainCam}");

--- a/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/EventListeners/LevelGameEventListener.cs
+++ b/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/EventListeners/LevelGameEventListener.cs
@@ -1,0 +1,6 @@
+﻿namespace GD
+{
+    public class LevelGameEventListener : BaseGameEventListener<GameLevel>
+    {
+    }
+}

--- a/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/EventListeners/LevelGameEventListener.cs.meta
+++ b/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/EventListeners/LevelGameEventListener.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 011f4f49762548898a9c1b71496a8b35
+timeCreated: 1702032891

--- a/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/GameEvents/LevelGameEvent.cs
+++ b/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/GameEvents/LevelGameEvent.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace GD
+{
+    [CreateAssetMenu(fileName = "LevelGameEvent", menuName = "DkIT/Scriptable Objects/Patterns/Events/Level", order = 1)]
+    public class LevelGameEvent : BaseGameEvent<GameLevel>
+    {
+    }
+}

--- a/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/GameEvents/LevelGameEvent.cs.meta
+++ b/Assets/ThirdParty/Niall/Scripts/Patterns/Events/Multi-parameter/GameEvents/LevelGameEvent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2e953b3003304bd38da59c9dbb1d76f9
+timeCreated: 1702032924


### PR DESCRIPTION
- used SearchableObjects in AssignPlayerToCinemachine.cs
- added LevelGameEvent type
- renamed LevelLoaded to LevelLoadedEvent while changing the type to LevelGameEvent, this also means changing the type in all the callback functions and exchanging EmptyGameEventListener's to LevelGameEventListener's
- also removed checks on existence of GameEvents in Bootloader, it should throw an error if we misconfigured it
- added ScoringSystem to Core Persistent Prefabs
- House prefab now has the LevelFinishReached.cs script and a triggerBox attached
- added a House prefab variant, it also got switched into the place of the previous house in level 1
- introduced LevelFinishedEvent which gets raised, when the house collider is triggered
- store highest score, highest stars, lowest damage and lowest time to finish in GameLevel (gets triggered with LevelFinishedEvent)
- modify high score per level from Scoring.cs
- export score, stars, and play duration through readonly properties for usage in the NextLevelScene
- added Listener for LevelFinishedEvent to Scoring Prefab